### PR TITLE
Fix typo

### DIFF
--- a/ltx2crossrefxml.pl
+++ b/ltx2crossrefxml.pl
@@ -304,7 +304,7 @@ extent permitted by law.
  use BibTeX::Parser::Author;
  use BibTeX::Parser;
  use LaTeX::ToUnicode;
- use IO::file;
+ use IO::File;
 
  my $USAGE = <<END;
 Usage: $0 [-c CONFIG] [-o OUTPUT] [--rpi-is-xml] LTXFILE...


### PR DESCRIPTION
There seems to be a typo introduced with the last commit. Maybe on a a filesystem that is not case sensitive this worked, but for me on Linux is doesn't.